### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Papers that are just theory with no experiments. In reverse chronological order.
 | 14 September 2023 | A “thoughtful” Local Friendliness no-go theorem: a prospective experiment with new assumptions to suit | Howard M. Wiseman, Eric G. Cavalcanti, and Eleanor G. Rieffel | https://quantum-journal.org/papers/q-2023-09-14-1112/ |
 | 13 September 2023 | A possibilistic no-go theorem on the Wigner's friend paradox | Marwan Haddara and Eric Cavalcanti | https://iopscience.iop.org/article/10.1088/1367-2630/aceea3/meta |
 | 24 May 2023 | Wigner's friend's memory and the no-signaling principle | Veronika Baumann and Časlav Brukner | https://arxiv.org/abs/2305.15497 |
-| 24 February 2023 |Friendly thoughts on thoughtful friendliness | Adrian Kent | https://arxiv.org/abs/2302.12707 |
+| 24 February 2023 | Friendly thoughts on thoughtful friendliness | Adrian Kent | https://arxiv.org/abs/2302.12707 |
+| 24 August 2022 | Events in quantum mechanics are maximally non-absolute | George Moreno, Ranieri Nery, Cristhiano Duarte, and  Rafael Chaves | https://quantum-journal.org/papers/q-2022-08-24-785/ |
 | 20 March 2021     | The View from a Wigner Bubble | Eric Cavalcanti | https://link.springer.com/article/10.1007/s10701-021-00417-0 |
 | 29 April 2018     | A No-Go Theorem for Observer-Independent Facts | Časlav Brukner | https://www.mdpi.com/1099-4300/20/5/350 |
 


### PR DESCRIPTION
Added  ["Events in quantum mechanics are maximally non-absolute"](https://quantum-journal.org/papers/q-2022-08-24-785/) a paper quantifying the discrepancy between what the friends see and what the wigners see in order to be able to violate the LF inequalities